### PR TITLE
Quick fix from HORN-9

### DIFF
--- a/src/main/java/org/apache/horn/funcs/Sigmoid.java
+++ b/src/main/java/org/apache/horn/funcs/Sigmoid.java
@@ -35,7 +35,7 @@ public class Sigmoid extends DoubleFunction {
 
   @Override
   public double applyDerivative(double value) {
-    return value * (1 - value);
+    return apply(value) * (1 - apply(value));
   }
 
 }


### PR DESCRIPTION
I noticed another error that was brought in, the derivative of the Sigmoid function is supposed to be 
```
f(x) = 1.0 / (1 + Math.exp(-x))
df(x)/dx = f(x)(1-f(x))
```
currently the class has the functions written as 
```
apply(x) = 1.0 / (1 + Math.exp(-x))
applyDerivative(x) = (x)(1-x)
```